### PR TITLE
Torrent Grouping

### DIFF
--- a/app/Http/Controllers/TorrentController.php
+++ b/app/Http/Controllers/TorrentController.php
@@ -585,7 +585,7 @@ class TorrentController extends Controller
                 ]);
                 $featured->save();
                 $appurl = env('APP_URL', 'http://unit3d.site');
-                Shoutbox::create(['user' => "1", 'mentions' => "1", 'message' => "Ladies and Gents, [url=url={$appurl}/torrents/" . $torrent->slug . "." . $torrent->id . "]" . $torrent->name . "[/url]
+                Shoutbox::create(['user' => "1", 'mentions' => "1", 'message' => "Ladies and Gents, [url={$appurl}/torrents/" . $torrent->slug . "." . $torrent->id . "]" . $torrent->name . "[/url]
             has been added to the Featured Torrents Slider by [url={$appurl}/" . Auth::user()->username . "." . Auth::user()->id . "]" . Auth::user()->username . "[/url]! Grab It While You Can! :fire:"]);
                 Cache::forget('shoutbox_messages');
             } else {
@@ -749,7 +749,7 @@ class TorrentController extends Controller
      * @access public
      * @return view::make poster.poster
      */
-    public function poster()
+    public function posterLayout()
     {
         $user = Auth::user();
         $torrents = Torrent::orderBy('created_at', 'DESC')->paginate(20);
@@ -837,4 +837,33 @@ class TorrentController extends Controller
             abort(403, 'Unauthorized action.');
         }
     }
+
+    /**
+     * Torrent Grouping
+     *
+     * @access public
+     *
+     */
+    public function groupingLayout() {
+        $user = Auth::user();
+        $torrents = Torrent::select('imdb')->distinct()->get();
+
+        return view('torrent.grouping', ['user' => $user, 'torrents' => $torrents]);
+    }
+
+    /**
+     * Torrent Grouping Results
+     *
+     * @access public
+     *
+     */
+    public function groupingResults($imdb) {
+        $user = Auth::user();
+        $client = new \App\Services\MovieScrapper(config('api-keys.tmdb') , config('api-keys.tvdb') , config('api-keys.omdb'));
+        $movie = $client->scrape('movie', 'tt'.$imdb);
+        $torrents = Torrent::where('imdb', $imdb)->get();
+
+        return view('torrent.grouping_results', ['user' => $user, 'torrents' => $torrents, 'movie' => $movie]);
+    }
+
 }

--- a/app/Http/Controllers/TorrentController.php
+++ b/app/Http/Controllers/TorrentController.php
@@ -846,7 +846,7 @@ class TorrentController extends Controller
      */
     public function groupingLayout() {
         $user = Auth::user();
-        $torrents = Torrent::select('imdb')->distinct()->get();
+        $torrents = Torrent::select('imdb')->distinct()->paginate(25);;
 
         return view('torrent.grouping', ['user' => $user, 'torrents' => $torrents]);
     }

--- a/resources/lang/en/common.php
+++ b/resources/lang/en/common.php
@@ -38,5 +38,6 @@ return [
 	'about' => 'About Us',
     'community' => 'Community',
     'buffer' => 'Buffer',
-	'times' => 'Times'
+	'times' => 'Times',
+	'name' => 'Name'
 ];

--- a/resources/views/torrent/grouping.blade.php
+++ b/resources/views/torrent/grouping.blade.php
@@ -75,5 +75,6 @@
     </div>
   </div>
   @endforeach
+  {{ $torrents->links() }}
 </div>
 @stop

--- a/resources/views/torrent/grouping.blade.php
+++ b/resources/views/torrent/grouping.blade.php
@@ -1,0 +1,79 @@
+@extends('layout.default')
+
+@section('title')
+<title>{{ trans('torrent.torrents') }} - {{ Config::get('other.title') }}</title>
+@stop
+
+@section('meta')
+<meta name="description" content="{{ trans('torrent.torrents') }}">
+@stop
+
+@section('breadcrumb')
+<li>
+  <a href="{{ route('torrents') }}" itemprop="url" class="l-breadcrumb-item-link">
+    <span itemprop="title" class="l-breadcrumb-item-link-title">{{ trans('torrent.torrents') }}</span>
+  </a>
+</li>
+<li>
+  <a href="{{ route('grouping') }}" itemprop="url" class="l-breadcrumb-item-link">
+    <span itemprop="title" class="l-breadcrumb-item-link-title">Grouping View</span>
+  </a>
+</li>
+@stop
+
+@section('content')
+<div class="container box">
+  <div class="header gradient light_blue">
+    <div class="inner_content">
+      <h1>Torrent Grouping</h1>
+    </div>
+  </div>
+  @foreach($torrents as $k => $t)
+  @php $client = new \App\Services\MovieScrapper(config('api-keys.tmdb') , config('api-keys.tvdb') , config('api-keys.omdb')) @endphp
+  @if($t->category_id == "2")
+  @php $movie = $client->scrape('tv', 'tt'.$t->imdb); @endphp
+  @else
+  @php $movie = $client->scrape('movie', 'tt'.$t->imdb); @endphp
+  @endif
+  <div class="row">
+    <div class="col-sm-12 movie-list">
+      <div class="pull-left">
+        <a href="#">
+          <img src="{{ $movie->poster }}" style="height:200px; margin-right:10px;" alt="{{ $movie->title }} Poster">
+        </a>
+      </div>
+      <h2 class="movie-title">
+          <a href="{{ route('grouping_results', ['imdb' => $t->imdb]) }}" title="{{ $movie->title }} ({{ $movie->releaseYear }})">{{ $movie->title }} ({{ $movie->releaseYear }})</a>
+          <span class="badge-user text-bold text-gold">Rating:
+            <span class="movie-rating-stars">
+              <i class="fa fa-star"></i>
+            </span>
+            @if($user->ratings == 1)
+            {{ $movie->imdbRating }}/10 ({{ $movie->imdbVotes }} votes)
+            @else
+            {{ $movie->tmdbRating }}/10 ({{ $movie->tmdbVotes }} votes)
+            @endif
+         </span>
+      </h2>
+      <div class="movie-details">
+        <p class="movie-plot">{{ $movie->plot }}</p>
+        <strong>ID:</strong>
+        <span class="badge-user"><a rel="nofollow" href="http://www.imdb.com/title/tt{{ $movie->imdb }}">{{ $movie->imdb }}</a></span>
+        <span class="badge-user"><a rel="nofollow" href="https://www.themoviedb.org/movie/{{ $movie->tmdb }}">{{ $movie->imdb }}</a></span>
+        <strong>Genre: </strong>
+        @if($movie->genres)
+        @foreach($movie->genres as $genre)
+        <span class="badge-user text-bold text-green">{{ $genre }}</span>
+        @endforeach
+        @endif
+      </div>
+      <br>
+      <ul class="list-inline">
+         @php $count = DB::table('torrents')->where('imdb',$t->imdb)->count(); @endphp
+        <li><i class="fa fa-files-o"></i> <strong>Torrents: </strong> {{ $count }}</li>
+      </ul>
+    </div>
+  </div>
+  @endforeach
+</div>
+@stop

--- a/resources/views/torrent/grouping_results.blade.php
+++ b/resources/views/torrent/grouping_results.blade.php
@@ -1,0 +1,197 @@
+@extends('layout.default')
+
+@section('title')
+<title>{{ trans('torrent.torrents') }} - {{ Config::get('other.title') }}</title>
+@stop
+
+@section('meta')
+<meta name="description" content="{{ trans('torrent.torrents') }}">
+@stop
+
+@section('breadcrumb')
+<li>
+  <a href="{{ route('torrents') }}" itemprop="url" class="l-breadcrumb-item-link">
+    <span itemprop="title" class="l-breadcrumb-item-link-title">{{ trans('torrent.torrents') }}</span>
+  </a>
+</li>
+<li>
+  <a href="{{ route('grouping') }}" itemprop="url" class="l-breadcrumb-item-link">
+    <span itemprop="title" class="l-breadcrumb-item-link-title">Grouping View</span>
+  </a>
+</li>
+<li>
+  <a href="{{ route('grouping_results', ['imdb' => $movie->imdb]) }}" itemprop="url" class="l-breadcrumb-item-link">
+    <span itemprop="title" class="l-breadcrumb-item-link-title">Grouping Results</span>
+  </a>
+</li>
+@stop
+
+@section('content')
+<div class="container box">
+  <div class="header gradient light_blue">
+    <div class="inner_content">
+      <h1>{{ $movie->title }} ({{ $movie->releaseYear }})</h1>
+    </div>
+  </div>
+<div class="row">
+  <div class="col-sm-12 movie-list">
+    <div class="pull-left">
+      <a href="#">
+        <img src="{{ $movie->poster }}" style="height:200px; margin-right:10px;" alt="{{ $movie->title }} Poster">
+      </a>
+    </div>
+    <h2 class="movie-title text-bold">
+        {{ $movie->title }} ({{ $movie->releaseYear }})
+        <span class="badge-user text-bold text-gold">Rating:
+          <span class="movie-rating-stars">
+            <i class="fa fa-star"></i>
+          </span>
+          @if($user->ratings == 1)
+          {{ $movie->imdbRating }}/10 ({{ $movie->imdbVotes }} votes)
+          @else
+          {{ $movie->tmdbRating }}/10 ({{ $movie->tmdbVotes }} votes)
+          @endif
+       </span>
+    </h2>
+    <div class="movie-details">
+      <p class="movie-plot">{{ $movie->plot }}</p>
+      <strong>ID:</strong>
+      <span class="badge-user"><a rel="nofollow" href="http://www.imdb.com/title/tt{{ $movie->imdb }}">{{ $movie->imdb }}</a></span>
+      <span class="badge-user"><a rel="nofollow" href="https://www.themoviedb.org/movie/{{ $movie->tmdb }}">{{ $movie->imdb }}</a></span>
+      <strong>Genre: </strong>
+      @if($movie->genres)
+      @foreach($movie->genres as $genre)
+      <span class="badge-user text-bold text-green">{{ $genre }}</span>
+      @endforeach
+      @endif
+    </div>
+    <br>
+    <ul class="list-inline">
+       <li><i class="fa fa-files-o"></i> <strong>Torrents: </strong> {{ $torrents->count() }}</li>
+    </ul>
+  </div>
+</div>
+
+
+<div class="panel panel-default panel-collapse">
+  <div class="panel-heading" data-toggle="collapse" data-target="#collapseRelatedTorrents">
+    <strong><a href="#">Torrents</a></strong>
+  </div>
+  <div id="collapseRelatedTorrents" class="panel-body collapse in">
+
+    <div class="torrents col-md-12">
+      <div class="table-responsive">
+        <table class="table table-condensed table-bordered table-striped table-hover">
+          <thead>
+            <tr>
+              <th>Poster</th>
+              <th>Category</th>
+              <th>Name</th>
+              <th><i class="fa fa-clock-o"></i></th>
+              <th><i class="fa fa-file"></i></th>
+              <th><i class="fa fa-check-square-o"></i></th>
+              <th><i class="fa fa-arrow-circle-up"></i></th>
+              <th><i class="fa fa-arrow-circle-down"></i></th>
+            </tr>
+          </thead>
+          <tbody id="result">
+             @foreach($torrents as $k => $t)
+            <tr>
+              <td>
+                <div class="torrent-poster pull-left"><img src="{{ $movie->poster }}" data-poster-mid="{{ $movie->poster }}" class="img-tor-poster torrent-poster-img-small" alt="Poster"></div>
+              </td>
+              <td>
+                <center>
+                    @if($t->category_id == "1")
+                    <i class="fa fa-film torrent-icon" data-toggle="tooltip" title="" data-original-title="Movie Torrent"></i>
+                    @elseif($t->category_id == "2")
+                    <i class="fa fa-tv torrent-icon" data-toggle="tooltip" title="" data-original-title="TV-Show Torrent"></i>
+                    @else
+                    <i class="fa fa-film torrent-icon" data-toggle="tooltip" title="" data-original-title="Movie Torrent"></i>
+                    @endif
+                  <br>
+                  <br>
+                  <span class="label label-success">{{ $t->type }}</span>
+                </center>
+              </td>
+              <td>
+                <a class="view-torrent" data-id="{{ $t->id }}" data-slug="{{ $t->slug }}" href="{{ route('torrent', array('slug' => $t->slug, 'id' => $t->id)) }}" data-toggle="tooltip" title="" data-original-title="{{ $t->name }}">{{ $t->name }}</a>
+                <a href="{{ route('download', array('slug' => $t->slug, 'id' => $t->id)) }}">&nbsp;&nbsp;
+                  <button class="btn btn-primary btn-circle" type="button" data-toggle="tooltip" title="" data-original-title="DOWNLOAD!"><i class="livicon" data-name="download" data-size="18" data-color="white" data-hc="white" data-l="true"></i></button>
+                </a>
+                <br>
+                <strong>
+                @if ($t->anon == 1)
+                <span class="badge-extra text-bold">
+                <i class="fa fa-upload"></i> By ANONYMOUS USER
+                @if ($user->id == $t->user->id || $user->group->is_modo)
+                <a href="{{ route('profil', ['username' => $t->user->username, 'id' => $t->user->id]) }}">({{ $t->user->username }})</a>
+                </span>
+                @endif
+                @else
+                <span class="badge-extra text-bold">
+                <i class="fa fa-upload"></i> By
+                <a href="{{ route('profil', ['username' => $t->user->username, 'id' => $t->user->id]) }}">{{ $t->user->username }}</a>
+                </span>
+                @endif
+
+                @if ($user->ratings == 1)
+                <a rel="nofollow" href="http://www.imdb.com/title/tt{{ $t->imdb }}">
+                <span class="badge-extra text-bold">
+                  <span class="text-gold movie-rating-stars">
+                    <i class="fa fa-star" data-toggle="tooltip" title="" data-original-title="View More"></i>
+                  </span>
+                  {{ $movie->imdbRating }}/10 ({{ $movie->imdbVotes }} votes)
+                </span>
+                </a>
+                @else
+                @if ($t->category_id == '2')
+                <a rel="nofollow" href="https://www.themoviedb.org/tv/34307">
+                <span class="badge-extra text-bold">
+                  <span class="text-gold movie-rating-stars">
+                    <i class="fa fa-star" data-toggle="tooltip" title="" data-original-title="View More"></i>
+                  </span>
+                  {{ $movie->tmdbRating }}/10 ({{ $movie->tmdbVotes }} votes)
+                </span>
+                </a>
+                @else
+                <a rel="nofollow" href="https://www.themoviedb.org/movie/34307">
+                <span class="badge-extra text-bold">
+                  <span class="text-gold movie-rating-stars">
+                    <i class="fa fa-star" data-toggle="tooltip" title="" data-original-title="View More"></i>
+                  </span>
+                  {{ $movie->tmdbRating }}/10 ({{ $movie->tmdbVotes }} votes)
+                </span>
+                </a>
+                @endif
+                @endif
+                <span class="badge-extra text-bold text-pink"><i class="fa fa-heart" data-toggle="tooltip" title="" data-original-title="Thanks Given"></i> {{ $t->thanks()->count() }}</span>
+                @if($t->stream == "1")<span class="badge-extra text-bold"><i class="fa fa-play text-red" data-toggle="tooltip" title="" data-original-title="Stream Optimized"></i> Stream Optimized</span> @endif
+                @if($t->doubleup == "1")<span class="badge-extra text-bold"><i class="fa fa-diamond text-green" data-toggle="tooltip" title="" data-original-title="Double upload"></i> Double Upload</span> @endif
+                @if($t->free == "1")<span class="badge-extra text-bold"><i class="fa fa-star text-gold" data-toggle="tooltip" title="" data-original-title="100% Free"></i> 100% Free</span> @endif
+                @if(config('other.freeleech') == true)<span class="badge-extra text-bold"><i class="fa fa-globe text-blue" data-toggle="tooltip" title="" data-original-title="Global FreeLeech"></i> Global FreeLeech</span> @endif
+                @if(config('other.doubleup') == true)<span class="badge-extra text-bold"><i class="fa fa-globe text-green" data-toggle="tooltip" title="" data-original-title="Double Upload"></i> Global Double Upload</span> @endif
+                @if($t->leechers >= "5") <span class="badge-extra text-bold"><i class="fa fa-fire text-orange" data-toggle="tooltip" title="" data-original-title="Hot!"></i> Hot!</span> @endif
+                @if($t->sticky == 1) <span class="badge-extra text-bold"><i class="fa fa-thumb-tack text-black" data-toggle="tooltip" title="" data-original-title="Sticky!"></i> Sticky!</span> @endif
+                @if($user->updated_at->getTimestamp() < $t->created_at->getTimestamp()) <span class="badge-extra text-bold"><i class="fa fa-magic text-black" data-toggle="tooltip" title="" data-original-title="NEW!"></i> NEW!</span> @endif
+                @if($t->highspeed == 1)<span class="badge-extra text-bold"><i class="fa fa-tachometer text-red" data-toggle="tooltip" title="" data-original-title="High Speeds!"></i> High Speeds!</span> @endif
+                </strong>
+              </td>
+
+              <td>
+                <time datetime="{{ date('Y-m-d H:m:s', strtotime($t->created_at)) }}">{{$t->created_at->diffForHumans()}}</time>
+              </td>
+              <td><span class="badge-extra text-blue text-bold">{{ $t->getSize() }}</span></td>
+              <td><span class="badge-extra text-orange text-bold">{{ $t->times_completed }} {{ trans('common.times') }}</span></td>
+              <td><span class="badge-extra text-green text-bold">{{ $t->seeders }}</span></td>
+              <td><span class="badge-extra text-red text-bold">{{ $t->leechers }}</span></td>
+            </tr>
+            @endforeach
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>
+</div>
+@stop

--- a/resources/views/torrent/torrents.blade.php
+++ b/resources/views/torrent/torrents.blade.php
@@ -146,6 +146,7 @@
   <strong>View:</strong>
   <a href="{{ route('torrents') }}" class="btn btn-xs btn-primary"><i class="fa fa-list"></i> Lists</a>
   <a href="{{ route('poster') }}" class="btn btn-xs btn-primary"><i class="fa fa-image"></i> Posters</a>
+  <a href="{{ route('grouping') }}" class="btn btn-xs btn-primary"><i class="fa fa-list"></i> Grouping</a>
 </div>
 </div>
 <!-- /Search -->

--- a/routes/web.php
+++ b/routes/web.php
@@ -173,9 +173,11 @@ Route::group(['middleware' => 'auth'], function () {
     Route::get('/torrents/{slug}.{id}/peers', 'TorrentController@peers')->name('peers');
     Route::get('/torrents/{slug}.{id}/history', 'TorrentController@history')->name('history');
     Route::any('/upload', 'TorrentController@upload')->name('upload');
-    Route::get('/download_check/{slug}.{id}', 'TorrentController@downloadCheck')->name('download_check');
-    Route::get('/download/{slug}.{id}', 'TorrentController@download')->name('download');
-    Route::get('/poster', 'TorrentController@poster')->name('poster');
+    Route::get('torrents/download_check/{slug}.{id}', 'TorrentController@downloadCheck')->name('download_check');
+    Route::get('torrents/download/{slug}.{id}', 'TorrentController@download')->name('download');
+    Route::get('torrents/poster', 'TorrentController@posterLayout')->name('poster');
+    Route::get('torrents/grouping', 'TorrentController@groupingLayout')->name('grouping');
+    Route::get('torrents/grouping/{imdb}', 'TorrentController@groupingResults')->name('grouping_results');
     Route::post('/torrents/{id}/delete', 'TorrentController@deleteTorrent')->name('delete');
     Route::get('/torrents/{id}/delete', 'TorrentController@deleteTorrent')->name('delete');
     Route::any('/torrents/{slug}.{id}/edit', 'TorrentController@edit')->name('edit');


### PR DESCRIPTION
This add a torrent grouping functionality. One can now view the torrents list page via the defaults list view, poster view and now torrent grouping view. 

Can be viewed on demo here:
https://unit3d.org/torrents/grouping

