### PR TITLE
Fix for MediaInfo stuff. Helper works! But View has to be tested (!)

### DIFF
--- a/app/Helpers/MediaInfo.php
+++ b/app/Helpers/MediaInfo.php
@@ -297,7 +297,7 @@ class MediaInfo
     {
         $output = ["general"=>[],"video"=>[],"audio"=>[]];
 
-        $generalCrumbs = array("format"=>"ucfirst","duration"=>NULL);
+        $general_crumbs = array("format"=>"ucfirst","duration"=>NULL);
 
         if($data['general'] === NULL){
             $output["general"] = NULL;

--- a/app/Http/Controllers/TorrentController.php
+++ b/app/Http/Controllers/TorrentController.php
@@ -483,6 +483,19 @@ class TorrentController extends Controller
             $featured = null;
         }
 
+        $general = null;
+        $video = null;
+        $settings = null;
+        $audio = null;
+        $general_crumbs = null;
+        $text_crumbs = null;
+        $subtitle = null;
+        $view_crumbs = null;
+        $video_crumbs = null;
+        $settings = null;
+        $audio_crumbs = null;
+        $subtitle = null;
+        $subtitle_crumbs = null;
         if ($torrent->mediainfo != null) {
             $parser = new \App\Helpers\MediaInfo;
             $parsed = $parser->parse($torrent->mediainfo);
@@ -496,16 +509,10 @@ class TorrentController extends Controller
             $audio_crumbs = $view_crumbs['audio'];
             $subtitle = $parsed['text'];
             $subtitle_crumbs = $view_crumbs['text'];
-        } else {
-            $general = null;
-            $video = null;
-            $settings = null;
-            $audio = null;
-            $subtitle = null;
         }
 
         return view('torrent.torrent', ['torrent' => $torrent, 'comments' => $comments, 'thanks' => $thanks, 'user' => $user, 'similar' => $similar,
-            'movie' => $movie, 'total_tips' => $total_tips, 'user_tips' => $user_tips, 'client' => $client, 'featured' => $featured, 'general' => $general,
+            'movie' => $movie, 'total_tips' => $total_tips, 'user_tips' => $user_tips, 'client' => $client, 'featured' => $featured, 'general' => $general, 'general_crumbs' => $general_crumbs, 'video_crumbs' => $video_crumbs, 'audio_crumbs' => $audio_crumbs, 'text_crumbs' => $text_crumbs,
             'video' => $video, 'audio' => $audio, 'subtitle' => $subtitle, 'settings' => $settings, 'uploader' => $uploader]);
     }
 

--- a/app/Http/Controllers/TorrentController.php
+++ b/app/Http/Controllers/TorrentController.php
@@ -486,11 +486,16 @@ class TorrentController extends Controller
         if ($torrent->mediainfo != null) {
             $parser = new \App\Helpers\MediaInfo;
             $parsed = $parser->parse($torrent->mediainfo);
+            $view_crumbs = $parser->prepareViewCrumbs($parsed);
             $general = $parsed['general'];
+            $general_crumbs = $view_crumbs['general'];
             $video = $parsed['video'];
-            $settings = $parsed['video'][0];
+            $video_crumbs = $view_crumbs['video'];
+            $settings = ($parsed['video'] !== NULL && isset($parsed['video'][0]) && isset($parsed['video'][0]['encoding_settings'])) ? $parsed['video'][0]['encoding_settings'] : NULL;
             $audio = $parsed['audio'];
+            $audio_crumbs = $view_crumbs['audio'];
             $subtitle = $parsed['text'];
+            $subtitle_crumbs = $view_crumbs['text'];
         } else {
             $general = null;
             $video = null;

--- a/resources/views/torrent/edit_tor.blade.php
+++ b/resources/views/torrent/edit_tor.blade.php
@@ -71,7 +71,7 @@
 
             <div class="form-group">
                 <label for="description">MediaInfo</label>
-                <textarea name="mediainfo" cols="30" rows="10" class="form-control" disabled>{{ $tor->mediainfo }}</textarea>
+                <textarea name="mediainfo" cols="30" rows="10" class="form-control">{{ $tor->mediainfo }}</textarea>
             </div>
 
             <label for="hidden" class="control-label">Anonymous Upload?</label>

--- a/resources/views/torrent/torrent.blade.php
+++ b/resources/views/torrent/torrent.blade.php
@@ -267,36 +267,74 @@
             <div class="panel-body torrent-desc">
                 <center><span class="text-bold text-blue">@emojione(':blue_heart:') Media Info Output @emojione(':blue_heart:')</span></center>
                 <br>
-                <span class="text-bold text-blue">@emojione(':name_badge:') FILE:</span>
-                <span class="text-bold"><em>{{ $general['file_name'] }}</em></span>
-                <br>
-                <br>
-                <span class="text-bold text-blue">@emojione(':information_source:') GENERAL:</span>
-                <span class="text-bold"><em>{{ ucfirst($general['format']) }} /  {{ $general['duration'] }}</em></span>
-                <br>
-                <br>
-                @foreach($video as $key => $v)
-                <span class="text-bold text-blue">@emojione(':projector:') VIDEO:</span>
-                <span class="text-bold"><em>{{ strtoupper($v['format']) }} / {{ $v['width'] }} x {{ $v['height'] }} / {{ $v['aspect_ratio'] }} / {{ $v['frame_rate'] }} / {{ $v['bit_depth'] }} / {{ $v['bit_rate'] }} / {{ $v['format_profile'] }} / {{ $v['scan_type'] }}</em></span>
-                <br>
-                <br>
-                @endforeach
-                @foreach($audio as $key => $a)
-                  <span class="text-bold text-blue">@emojione(':loud_sound:') AUDIO {{ ++$key }}:</span>
-                  <span class="text-bold"><em>{{ ucfirst($a['language']) }} / {{ strtoupper($a['format']) }} / {{ $a['channels'] }} / {{ $a['bit_rate'] }}</em></span>
+                @if($general !== null && isset($general['file_name']))
+                  <span class="text-bold text-blue">@emojione(':name_badge:') FILE:</span>
+                  <span class="text-bold"><em>{{ $general['file_name'] }}</em></span>
                   <br>
-                @endforeach
+                  <br>
+                @endif
+                @if($general_crumbs !== null)
+                  <span class="text-bold text-blue">@emojione(':information_source:') GENERAL:</span>
+                  <span class="text-bold"><em>
+                      @foreach($general_crumbs as $crumb)
+                        {{ $crumb }}
+                        @if(!$loop->last)
+                          /
+                        @endif
+                      @endforeach
+                    </em></span>
+                  <br>
+                  <br>
+                @endif
+                @if($video_crumbs !== null)
+                  @foreach($video_crumbs as $key => $v)
+                    <span class="text-bold text-blue">@emojione(':projector:') VIDEO:</span>
+                    <span class="text-bold"><em>
+                        @foreach($v as $crumb)
+                          {{ $crumb }}
+                          @if(!$loop->last)
+                            /
+                          @endif
+                        @endforeach
+                      </em></span>
+                    <br>
+                    <br>
+                  @endforeach
+                @endif
+                @if($audio_crumbs !== null)
+                  @foreach($audio_crumbs as $key => $a)
+                  <span class="text-bold text-blue">@emojione(':loud_sound:') AUDIO {{ ++$key }}:</span>
+                  <span class="text-bold"><em>
+                      @foreach($a as $crumb)
+                        {{ $crumb }}
+                        @if(!$loop->last)
+                          /
+                        @endif
+                      @endforeach
+                    </em></span>
+                  <br>
+                  @endforeach
+                @endif
                 <br>
-                @foreach($subtitle as $key => $s)
-                <span class="text-bold text-blue">@emojione(':speech_balloon:') SUBTITLE {{ ++$key }}:</span>
-                <span class="text-bold"><em>{{ ucfirst($s['language']) }} / {{ $s['codec'] }}</em></span>
-                <br>
-                @endforeach
-                {{--@if($settings['encoding_settings'])
+                @if($text_crumbs !== null)
+                  @foreach($subtitle as $key => $s)
+                  <span class="text-bold text-blue">@emojione(':speech_balloon:') SUBTITLE {{ ++$key }}:</span>
+                  <span class="text-bold"><em>
+                      @foreach($s as $crumb)
+                          {{ $crumb }}
+                          @if(!$loop->last)
+                            /
+                        @endif
+                      @endforeach
+                    </em></span>
+                  <br>
+                  @endforeach
+                @endif
+                {{--@if($settings)
                 <br>
                 <span class="text-bold text-blue">@emojione(':gear:') ENCODE SETTINGS:</span>
                 <br>
-                <div class="decoda-code text-black">{{ $settings['encoding_settings'] }}</div>
+                <div class="decoda-code text-black">{{ $settings }}</div>
                 @endif--}}
                 <br>
                 <br>

--- a/resources/views/torrent/upload.blade.php
+++ b/resources/views/torrent/upload.blade.php
@@ -152,7 +152,7 @@
 
       <center>
         <button type="submit" name="preview" value="true" id="preview" class="btn btn-warning">Preview</button>
-        <button id="add" class="btn btn-default" disabled>Add MediaInfo Parser</button>
+        <button id="add" class="btn btn-default">Add MediaInfo Parser</button>
         <button type="submit" name="post" value="true" id="post" class="btn btn-primary">Upload</button>
       </center>
         <br>


### PR DESCRIPTION
Did test the MediaInfo helper with a local script, but I don't have the environment for the whole Laravel thing, so someone will have to test whether the view works as it is. I didn't get any syntax errors, so I hope there won't be any major issues.

Changed up a couple of things, like adding the "title" property to the display and changing "codec" to "format" for subtitles (because it doesn't work well for m2ts files).

Also, I removed the blanket strtolower and added it where it was necessary (to section and property recognition and some of the property parsers). The upside of this is that a lot of MediaInfo information that uses both uppercase and lowercase is now fixed.

Added a shitton of security tests for non-existent properties etc. (both in view and helper), so there should be no more exceptions.