### PR TITLE
Fix silly mistake with wrong variable name in view

### DIFF
--- a/resources/views/torrent/torrent.blade.php
+++ b/resources/views/torrent/torrent.blade.php
@@ -317,7 +317,7 @@
                 @endif
                 <br>
                 @if($text_crumbs !== null)
-                  @foreach($subtitle as $key => $s)
+                  @foreach($text_crumbs as $key => $s)
                   <span class="text-bold text-blue">@emojione(':speech_balloon:') SUBTITLE {{ ++$key }}:</span>
                   <span class="text-bold"><em>
                       @foreach($s as $crumb)


### PR DESCRIPTION
This should be the reason why subtitles are not shown.